### PR TITLE
Fix entity type issue with wakatime CLI's latest version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const debounce = require('lodash.debounce')
 const exec = require('child_process').exec
-const command = '/usr/local/bin/wakatime --entity Terminal --entitytype app --plugin "hyper-wakatime/0.0.1" --project "<<LAST_PROJECT>>"'
+const command = '/usr/local/bin/wakatime --entity Terminal --entity-type app --plugin "hyper-wakatime/0.0.2" --project "<<LAST_PROJECT>>"'
 
 function sendHearbeat() {
   exec(command, function cb(error, stdout, stderr) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperwakatime",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Hyperterm + Wakatime plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
With the latest version of wakatime-cli, this plugin broke. They added a `-` in the middle of the `--entitytype` parameter.

I corrected it and pushed a fix, since it might be useful to others. If you have any questions or need additional info, please let me know :)

Thank you for making this, saved me a little bit of time!